### PR TITLE
Use of javax support lib for annotation instead of android.support lib

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,5 +45,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.ost:ost-wallet-sdk-android:2.2.1'
+    implementation 'com.ost:ost-wallet-sdk-android:2.2.2'
 }

--- a/android/src/main/java/com/ostwalletrnsdk/OstRNSdkJsonApiModule.java
+++ b/android/src/main/java/com/ostwalletrnsdk/OstRNSdkJsonApiModule.java
@@ -10,9 +10,6 @@
 
 package com.ostwalletrnsdk;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -24,6 +21,9 @@ import com.ost.walletsdk.workflows.errors.OstError;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class OstRNSdkJsonApiModule extends ReactContextBaseJavaModule {
 
@@ -119,7 +119,7 @@ public class OstRNSdkJsonApiModule extends ReactContextBaseJavaModule {
         }
 
         @Override
-        public void onOstJsonApiError(@NonNull OstError err, @Nullable JSONObject data) {
+        public void onOstJsonApiError(@Nonnull OstError err, @Nullable JSONObject data) {
             try {
                 if (null == data) data = new JSONObject();
 

--- a/android/src/main/java/com/ostwalletrnsdk/OstWorkFlowCallbackImpl.java
+++ b/android/src/main/java/com/ostwalletrnsdk/OstWorkFlowCallbackImpl.java
@@ -30,7 +30,6 @@ import com.ostwalletrnsdk.sdkIntracts.OstDeviceRegisteredWrap;
 import com.ostwalletrnsdk.sdkIntracts.OstPinAcceptWrap;
 import com.ostwalletrnsdk.sdkIntracts.OstVerifyDataWrap;
 
-import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.HashMap;


### PR DESCRIPTION
Use of javax support lib for annotation instead of android.support lib and version update of OstSdk to v2.2.2